### PR TITLE
Fix gemini response handling

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -109,7 +109,7 @@ News items should only contain 'title' and 'summary'.
       },
     });
 
-    let jsonStr = response.text.trim();
+    let jsonStr = (response.text ?? '').trim();
     const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
     const match = jsonStr.match(fenceRegex);
     if (match && match[1]) {
@@ -203,7 +203,7 @@ News items should only contain 'title' and 'summary'. Do NOT include 'classifica
         temperature: 0.7,
       },
     });
-    let jsonStr = response.text.trim();
+    let jsonStr = (response.text ?? '').trim();
     const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
     const match = jsonStr.match(fenceRegex);
     if (match && match[1]) {
@@ -278,7 +278,7 @@ Do NOT include a "trend" field.
       },
     });
 
-    let jsonStr = response.text.trim();
+    let jsonStr = (response.text ?? '').trim();
     const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
     const match = jsonStr.match(fenceRegex);
     if (match && match[1]) {


### PR DESCRIPTION
## Summary
- handle undefined `response.text` when parsing Gemini responses

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68574f21f7c88333935a28d76db77659